### PR TITLE
Fix ValueError

### DIFF
--- a/check.d/prometheus.py
+++ b/check.d/prometheus.py
@@ -58,10 +58,10 @@ class GenericCheck(PrometheusCheck):
         else:
             format = format.upper()
 
-        content_type, data = self.poll(endpoint, headers=headers, pFormat=format)
+        response = self.poll(endpoint, headers=headers, pFormat=format)
         for metric in filter(
                 lambda m: filterMetric(m, drops, keeps),
-                self.parse_metric_family(data, content_type)):
+                self.parse_metric_family(response)):
                 # Since dd-agent 5.21.0 according to https://github.com/DataDog/dd-agent/commit/e747b69
                 if callable(getattr(self, '_submit', None)):
                     self._submit(metric.name, metric, send_histograms_buckets,


### PR DESCRIPTION
Resolves #7 

I changed the way to receive return value to resolve `ValueError`.

Links to the line numbers/files in the dd-agent source code that related the code in this PR:
* [poll()](https://github.com/DataDog/dd-agent/blob/master/checks/prometheus_mixins.py#L412-L428)
* [parse_metric_family()](https://github.com/DataDog/dd-agent/blob/master/checks/prometheus_mixins.py#L130-L144)